### PR TITLE
Mount vagrant_data with write permissions

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -62,7 +62,8 @@ Vagrant.configure("2") do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder "./vagrant_data", "/home/vagrant/vagrant_data"
+  config.vm.synced_folder "./vagrant_data", "/home/vagrant/vagrant_data",
+     mount_options: ["dmode=775,fmode=777"]
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.


### PR DESCRIPTION
This sets permissions on the mounted file in vagrant (called "vagrant_data") to enable the user to write to it.  Previously the user was able to create files in the vagrant_data directory but was not able to clone git repos.  This fixes that problem.