### PR TITLE
Feature/vagrantfile

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure("2") do |config|
       exec "vagrant " + ARGV.join(' ')
   end
 
-  config.disksize.size = "50GB"
+  config.disksize.size = "64GB"
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
@@ -80,7 +80,7 @@ Vagrant.configure("2") do |config|
      vb.memory = "12288"
 
      # Customize the number of cores in the VM:
-     vb.cpus = "6"
+     vb.cpus = "12"
    end
 
   #

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -93,6 +93,7 @@ Vagrant.configure("2") do |config|
     set -e             
     apt-get update
     apt-get install -y build-essential python gcc curl
+    apt-get install -y autoconf pkg-config libtool autoconf-archive
     apt-get update
   EOF
 
@@ -104,8 +105,11 @@ Vagrant.configure("2") do |config|
     cd $HOME/build
     git clone --recursive https://github.com/hpc/charliecloud.git
     cd charliecloud
+    ./autogen.sh
+    ./configure --prefix=/usr/local --disable-tests --disable-html
     make
-    sudo make install PREFIX=/usr/local
+    sudo make install
+    cd $HOME
     rm -rf $HOME/build
   EOF
 
@@ -141,7 +145,6 @@ Vagrant.configure("2") do |config|
     sudo ./mconfig
     sudo make -C builddir
     sudo make -C builddir install
-    sudo rm /opt/singularity/singularity-${VERSION}.tar.gz
 
   EOF
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -145,6 +145,7 @@ Vagrant.configure("2") do |config|
     sudo ./mconfig
     sudo make -C builddir
     sudo make -C builddir install
+    sudo rm /opt/singularity/singularity-${VERSION}.tar.gz
 
   EOF
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -91,6 +91,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "environment", type: "shell", privileged: true,
                        inline: <<-EOF
     set -e             
+    export DEBIAN_FRONTEND=noninteractive
     apt-get update
     apt-get install -y build-essential python gcc curl
     apt-get install -y autoconf pkg-config libtool autoconf-archive
@@ -101,6 +102,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "charliecloud", type: "shell", privileged: false,
                        inline: <<-EOF
     set -e             
+    export DEBIAN_FRONTEND=noninteractive
     mkdir -p $HOME/build
     cd $HOME/build
     git clone --recursive https://github.com/hpc/charliecloud.git
@@ -117,6 +119,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "singularity", type: "shell", privileged: false,
                       inline: <<-EOF
     set -e
+    export DEBIAN_FRONTEND=noninteractive
 
     # package dependencies
     sudo apt-get install -y libssl-dev uuid-dev libgpgme11-dev squashfs-tools


### PR DESCRIPTION
During the Academy, we tried installing JEDI on someone's laptop and the ```vagrant up``` command failed on the Charliecloud install.  It seems that they have changed their installation procedure - they now use autoconfig!  This works for me.