### PR TITLE
reduce size of intel 19 container by deleting unwanted directories

### DIFF
--- a/Dockerfile.intel19-impi-dev
+++ b/Dockerfile.intel19-impi-dev
@@ -2,6 +2,7 @@ FROM ubuntu:18.04
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        apt-utils \
         bc \
         bison \
         build-essential \
@@ -23,6 +24,7 @@ RUN apt-get update -y && \
         libssl-dev \
         libx11-dev \
         libxml2-dev \
+        linux-headers-aws \
         lsb-release \
         man-db \
         nano \
@@ -48,17 +50,22 @@ RUN apt-get update -y && \
         build-essential \
         cpio && \
     rm -rf /var/lib/apt/lists/*
-COPY ./intel_tarballs/parallel_studio_xe_2019_update5_cluster_edition.tgz /var/tmp/parallel_studio_xe_2019_update5_cluster_edition.tgz
+COPY ./intel_tarballs/parallel_studio_xe_2020_update1_cluster_edition_online.tgz /var/tmp/parallel_studio_xe_2020_update1_cluster_edition_online.tgz
 COPY ./intel_license/COM_L___LXMW-67CW6CHW.lic /var/tmp/license.lic
-RUN mkdir -p /var/tmp && tar -x -f /var/tmp/parallel_studio_xe_2019_update5_cluster_edition.tgz -C /var/tmp -z && \
-    sed -i -e 's/^#\?\(COMPONENTS\)=.*/\1=intel-icc__x86_64;intel-ifort__x86_64;intel-mkl-core__x86_64;intel-ifort-common__noarch;intel-icx__x86_64;intel-icc-common__noarch;intel-icc-common-ps__noarch;intel-mkl-cluster__x86_64;intel-mkl-gnu__x86_64;intel-mkl-doc__noarch;intel-mkl-doc-ps__noarch;intel-mkl-common-ps__noarch;intel-mkl-core-ps__x86_64;intel-mkl-gnu-rt__x86_64;intel-mkl-common__noarch;intel-mkl-core-f__x86_64;intel-mkl-gnu-f__x86_64;intel-mkl-f95-common__noarch;intel-mkl-f__x86_64;intel-mkl-common-f__noarch;intel-mkl-cluster-c__noarch;intel-mkl-common-c-ps__noarch;intel-mkl-core-c__x86_64;intel-mkl-gnu-c__x86_64;intel-mkl-common-c__noarch;intel-mpi-rt__x86_64;intel-mpi-sdk__x86_64;intel-mpi-installer-license__x86_64;intel-mpi-psxe__x86_64;intel-mpi-rt-psxe__x86_64;intel-mkl-psxe__noarch;intel-ippcp-psxe__noarch;intel-psxe-common__noarch;intel-ippcp-psxe__noarch;intel-psxe-licensing__noarch;intel-icsxe-pset;intel-icsxe__noarch;intel-imb__x86_64;intel-ips__noarch;intel-ipsc__noarch;intel-ipsf__noarch;intel-openmp__x86_64;intel-openmp-common__noarch;intel-openmp-common-icc__noarch;intel-openmp-common-ifort__noarch;intel-openmp-ifort__x86_64;intel-comp__x86_64;intel-comp-l-all-common__noarch;intel-comp-l-all-vars__noarch;intel-comp-nomcu-vars__noarch;intel-comp-ps__x86_64;intel-comp-ps-ss__x86_64;intel-comp-ps-ss-bec__x86_64;intel-comp-ps-ss-bec-32bit__x86_64/g' \
+RUN mkdir -p /var/tmp && tar -x -f /var/tmp/parallel_studio_xe_2020_update1_cluster_edition_online.tgz -C /var/tmp -z && \
+    sed -i -e 's/^#\?\(COMPONENTS\)=.*/\1=intel-icc__x86_64;intel-ifort__x86_64;intel-mkl-core__x86_64;intel-ifort-common__noarch;intel-icx__x86_64;intel-icc-common__noarch;intel-icc-common-ps__noarch;intel-mkl-cluster__x86_64;intel-mkl-gnu__x86_64;intel-mkl-doc__noarch;intel-mkl-doc-ps__noarch;intel-mkl-common-ps__noarch;intel-mkl-core-ps__x86_64;intel-mkl-gnu-rt__x86_64;intel-mkl-common__noarch;intel-mkl-core-f__x86_64;intel-mkl-gnu-f__x86_64;intel-mkl-f95-common__noarch;intel-mkl-f__x86_64;intel-mkl-common-f__noarch;intel-mkl-cluster-c__noarch;intel-mkl-common-c-ps__noarch;intel-mkl-core-c__x86_64;intel-mkl-gnu-c__x86_64;intel-mkl-common-c__noarch;intel-mpi-rt__x86_64;intel-mpi-sdk__x86_64;intel-mpi-installer-license__x86_64;intel-mpi-psxe__x86_64;intel-mpi-rt-psxe__x86_64;intel-mkl-psxe__noarch;intel-ippcp-psxe__noarch;intel-psxe-common__noarch;intel-ippcp-psxe__noarch;intel-psxe-licensing__noarch;intel-icsxe-pset;intel-icsxe__noarch;intel-imb__x86_64;intel-ips__noarch;intel-ipsc__noarch;intel-ipsf__noarch;intel-openmp__x86_64;intel-openmp-common__noarch;intel-openmp-common-icc__noarch;intel-openmp-common-ifort__noarch;intel-openmp-ifort__x86_64;intel-comp__x86_64;intel-comp-l-all-common__noarch;intel-comp-l-all-vars__noarch;intel-comp-nomcu-vars__noarch;intel-comp-ps__x86_64;intel-comp-ps-ss-bec__x86_64/g' \
         -e 's|^#\?\(PSET_INSTALL_DIR\)=.*|\1=/opt/intel|g' \
         -e 's/^#\?\(ACCEPT_EULA\)=.*/\1=accept/g' \
         -e 's/^#\?\(ACTIVATION_TYPE\)=.*/\1=license_file/g' \
-        -e 's|^#\?\(ACTIVATION_LICENSE_FILE\)=.*|\1=/var/tmp/license.lic|g' /var/tmp/parallel_studio_xe_2019_update5_cluster_edition/silent.cfg && \
-    cd /var/tmp/parallel_studio_xe_2019_update5_cluster_edition && ./install.sh --silent=silent.cfg && \
-    rm -rf /var/tmp/parallel_studio_xe_2019_update5_cluster_edition.tgz /var/tmp/parallel_studio_xe_2019_update5_cluster_edition
+        -e 's|^#\?\(ACTIVATION_LICENSE_FILE\)=.*|\1=/var/tmp/license.lic|g' /var/tmp/parallel_studio_xe_2020_update1_cluster_edition_online/silent.cfg && \
+    cd /var/tmp/parallel_studio_xe_2020_update1_cluster_edition_online && ./install.sh --silent=silent.cfg && \
+    rm -rf /var/tmp/parallel_studio_xe_2020_update1_cluster_edition_online.tgz /var/tmp/parallel_studio_xe_2020_update1_cluster_edition_online
 RUN echo "source /opt/intel/compilers_and_libraries/linux/bin/compilervars.sh intel64" >> /etc/bash.bashrc
+
+RUN rm -rf /opt/intel/advisor* /opt/intel/vtune* /opt/intel/inspector* && \
+    rm -rf /opt/intel/ide_support_2020 /opt/intel/performance_snapshot /opt/intel/conda_channel && \
+    rm -rf /opt/intel/compilers_and_libraries_2020/linux/lib/ia32* && \
+    rm -rf /opt/intel/compilers_and_libraries_2020.1.217/linux/tbb/lib/ia32*
 
 # CMake version 3.13.0
 RUN apt-get update -y && \
@@ -133,7 +140,7 @@ ENV BOOST_ROOT=/usr/local \
 RUN cd /root && \
     git clone https://github.com/jcsda/jedi-stack.git && \
     cd jedi-stack/buildscripts && \
-    git checkout develop && \
+    git checkout feature/new-containers && \
     ./build_stack.sh "container-intel-impi-dev" && \
     mv ../jedi-stack-contents.log /etc && \
     chmod a+r /etc/jedi-stack-contents.log && \

--- a/build_intel_dev_container.sh
+++ b/build_intel_dev_container.sh
@@ -29,7 +29,7 @@ if [[ $(echo ${CNAME} | cut -d- -f1) = "intel17" ]]; then
     export INTEL_TARBALL='./intel_tarballs/parallel_studio_xe_2017_update1.tgz'
     export INTEL_CONTEXT='./context17'
 elif [[ $(echo ${CNAME} | cut -d- -f1) = "intel19" ]]; then
-    export INTEL_TARBALL='./intel_tarballs/parallel_studio_xe_2019_update5_cluster_edition.tgz'
+    export INTEL_TARBALL='./intel_tarballs/parallel_studio_xe_2020_update1_cluster_edition_online.tgz'
     export INTEL_CONTEXT='./context19'
 fi
 

--- a/intel19-impi-dev.py
+++ b/intel19-impi-dev.py
@@ -9,6 +9,9 @@ import os
 # Base image
 Stage0.baseimage('ubuntu:18.04')
 
+# get optional user arguments
+reduced_size = USERARG.get('reduced', 'True')
+
 Stage0 += apt_get(ospackages=['build-essential','tcsh','csh','ksh','git',
                               'openssh-server','libncurses-dev','libssl-dev',
                               'libx11-dev','less','man-db','tk','tcl','swig',
@@ -17,7 +20,7 @@ Stage0 += apt_get(ospackages=['build-essential','tcsh','csh','ksh','git',
                               'libcurl4-openssl-dev','nano','screen', 'libasound2',
                               'libgtk2.0-common','software-properties-common',
                               'libpango-1.0.0','xserver-xorg','dirmngr',
-                              'gnupg2','lsb-release'])
+                              'gnupg2','lsb-release','apt-utils','linux-headers-aws'])
 
 # update apt keys
 Stage0 += shell(commands=['apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157',
@@ -27,7 +30,7 @@ Stage0 += shell(commands=['apt-key adv --keyserver keyserver.ubuntu.com --recv-k
 
 # Install Intel compilers, mpi, and mkl 
 Stage0 += intel_psxe(eula=True, license=os.getenv('INTEL_LICENSE_FILE',default='../intel_license/COM_L___LXMW-67CW6CHW.lic'),
-                     tarball=os.getenv('INTEL_TARBALL',default='intel_tarballs/parallel_studio_xe_2019_update5_cluster_edition.tgz'),
+                     tarball=os.getenv('INTEL_TARBALL',default='intel_tarballs/parallel_studio_xe_2020_update1_cluster_edition_online.tgz'),
                      psxevars=True, components=['intel-icc__x86_64',
                       'intel-ifort__x86_64', 'intel-mkl-core__x86_64',
                       'intel-ifort-common__noarch',
@@ -77,10 +80,14 @@ Stage0 += intel_psxe(eula=True, license=os.getenv('INTEL_LICENSE_FILE',default='
                       'intel-comp-l-all-vars__noarch',
                       'intel-comp-nomcu-vars__noarch',
                       'intel-comp-ps__x86_64',
-                      'intel-comp-ps-ss__x86_64',
-                      'intel-comp-ps-ss-bec__x86_64',
-                      'intel-comp-ps-ss-bec-32bit__x86_64',
-])
+                      'intel-comp-ps-ss-bec__x86_64'])
+
+# component specification still isn't working so delete directories manually
+if (reduced_size.lower() == "true"):
+   Stage0 += shell(commands=['rm -rf /opt/intel/advisor* /opt/intel/vtune* /opt/intel/inspector*',
+             'rm -rf /opt/intel/ide_support_2020 /opt/intel/performance_snapshot /opt/intel/conda_channel',
+             'rm -rf /opt/intel/compilers_and_libraries_2020/linux/lib/ia32*',
+             'rm -rf /opt/intel/compilers_and_libraries_2020.1.217/linux/tbb/lib/ia32*'])
 
 ## get an up-to-date version of CMake
 Stage0 += cmake(eula=True,version="3.13.0")
@@ -132,7 +139,7 @@ Stage0 += environment(variables={'NETCDF':'/usr/local',
 Stage0 += shell(commands=['cd /root', 
     'git clone https://github.com/jcsda/jedi-stack.git',
     'cd jedi-stack/buildscripts',
-    'git checkout develop',
+    'git checkout feature/new-containers',
     './build_stack.sh "container-intel-impi-dev"',
     'mv ../jedi-stack-contents.log /etc',
     'chmod a+r /etc/jedi-stack-contents.log',


### PR DESCRIPTION
This is what was used to generate the new intel 19 docker container for CI testing.  The size of the compressed docker file on S3 is 4.3 GB, which is actually smaller than the intel 17 containers we've been using previously (6 GB).   This PR also includes an upgrade to the latest intel parallel studio 2020.1, which has version 19.1.1.217 of the compilers.