### PR TITLE
Update script, intel-dev singularity build

### DIFF
--- a/Dockerfile.intel19-impi-dev
+++ b/Dockerfile.intel19-impi-dev
@@ -50,16 +50,16 @@ RUN apt-get update -y && \
         build-essential \
         cpio && \
     rm -rf /var/lib/apt/lists/*
-COPY intel_tarballs/parallel_studio_xe_2020_update1_cluster_edition_online.tgz /var/tmp/parallel_studio_xe_2020_update1_cluster_edition_online.tgz
-COPY ../intel_license/COM_L___LXMW-67CW6CHW.lic /var/tmp/license.lic
-RUN mkdir -p /var/tmp && tar -x -f /var/tmp/parallel_studio_xe_2020_update1_cluster_edition_online.tgz -C /var/tmp -z && \
+COPY ./intel_tarballs/parallel_studio_xe_2020_cluster_edition.tgz /var/tmp/parallel_studio_xe_2020_cluster_edition.tgz
+COPY ./intel_license/COM_L___LXMW-67CW6CHW.lic /var/tmp/license.lic
+RUN mkdir -p /var/tmp && tar -x -f /var/tmp/parallel_studio_xe_2020_cluster_edition.tgz -C /var/tmp -z && \
     sed -i -e 's/^#\?\(COMPONENTS\)=.*/\1=intel-icc__x86_64;intel-ifort__x86_64;intel-mkl-core__x86_64;intel-ifort-common__noarch;intel-icx__x86_64;intel-icc-common__noarch;intel-icc-common-ps__noarch;intel-mkl-cluster__x86_64;intel-mkl-gnu__x86_64;intel-mkl-doc__noarch;intel-mkl-doc-ps__noarch;intel-mkl-common-ps__noarch;intel-mkl-core-ps__x86_64;intel-mkl-gnu-rt__x86_64;intel-mkl-common__noarch;intel-mkl-core-f__x86_64;intel-mkl-gnu-f__x86_64;intel-mkl-f95-common__noarch;intel-mkl-f__x86_64;intel-mkl-common-f__noarch;intel-mkl-cluster-c__noarch;intel-mkl-common-c-ps__noarch;intel-mkl-core-c__x86_64;intel-mkl-gnu-c__x86_64;intel-mkl-common-c__noarch;intel-mpi-rt__x86_64;intel-mpi-sdk__x86_64;intel-mpi-installer-license__x86_64;intel-mpi-psxe__x86_64;intel-mpi-rt-psxe__x86_64;intel-mkl-psxe__noarch;intel-ippcp-psxe__noarch;intel-psxe-common__noarch;intel-ippcp-psxe__noarch;intel-psxe-licensing__noarch;intel-icsxe-pset;intel-icsxe__noarch;intel-imb__x86_64;intel-ips__noarch;intel-ipsc__noarch;intel-ipsf__noarch;intel-openmp__x86_64;intel-openmp-common__noarch;intel-openmp-common-icc__noarch;intel-openmp-common-ifort__noarch;intel-openmp-ifort__x86_64;intel-comp__x86_64;intel-comp-l-all-common__noarch;intel-comp-l-all-vars__noarch;intel-comp-nomcu-vars__noarch;intel-comp-ps__x86_64;intel-comp-ps-ss-bec__x86_64/g' \
         -e 's|^#\?\(PSET_INSTALL_DIR\)=.*|\1=/opt/intel|g' \
         -e 's/^#\?\(ACCEPT_EULA\)=.*/\1=accept/g' \
         -e 's/^#\?\(ACTIVATION_TYPE\)=.*/\1=license_file/g' \
-        -e 's|^#\?\(ACTIVATION_LICENSE_FILE\)=.*|\1=/var/tmp/license.lic|g' /var/tmp/parallel_studio_xe_2020_update1_cluster_edition_online/silent.cfg && \
-    cd /var/tmp/parallel_studio_xe_2020_update1_cluster_edition_online && ./install.sh --silent=silent.cfg && \
-    rm -rf /var/tmp/parallel_studio_xe_2020_update1_cluster_edition_online.tgz /var/tmp/parallel_studio_xe_2020_update1_cluster_edition_online
+        -e 's|^#\?\(ACTIVATION_LICENSE_FILE\)=.*|\1=/var/tmp/license.lic|g' /var/tmp/parallel_studio_xe_2020_cluster_edition/silent.cfg && \
+    cd /var/tmp/parallel_studio_xe_2020_cluster_edition && ./install.sh --silent=silent.cfg && \
+    rm -rf /var/tmp/parallel_studio_xe_2020_cluster_edition.tgz /var/tmp/parallel_studio_xe_2020_cluster_edition
 RUN echo "source /opt/intel/compilers_and_libraries/linux/bin/compilervars.sh intel64" >> /etc/bash.bashrc
 
 RUN rm -rf /opt/intel/advisor* /opt/intel/vtune* /opt/intel/inspector* && \

--- a/build_intel_dev_container.sh
+++ b/build_intel_dev_container.sh
@@ -29,7 +29,7 @@ if [[ $(echo ${CNAME} | cut -d- -f1) = "intel17" ]]; then
     export INTEL_TARBALL='./intel_tarballs/parallel_studio_xe_2017_update1.tgz'
     export INTEL_CONTEXT='./context17'
 elif [[ $(echo ${CNAME} | cut -d- -f1) = "intel19" ]]; then
-    export INTEL_TARBALL='./intel_tarballs/parallel_studio_xe_2020_update1_cluster_edition_online.tgz'
+    export INTEL_TARBALL='./intel_tarballs/parallel_studio_xe_2020_cluster_edition.tgz'
     export INTEL_CONTEXT='./context19'
 fi
 
@@ -83,6 +83,23 @@ if [[ $ans == y ]] ; then
   aws s3 cp containers/docker-${CNAME}.tar.gz s3://privatecontainers/docker-jedi-${CNAME}.tar.gz
 else
   echo "Not sending to Amazon S3"
+fi
+
+echo "=============================================================="
+echo "   Building Singularity Image"
+echo "=============================================================="
+# Optionally build the Singularity image
+get_ans "Build Singularity image?"
+if [[ $ans == y ]] ; then
+    echo "Building Singularity image"
+    rm -f singularity_build.log
+    sudo singularity build containers/jedi-${CNAME}.sif docker-daemon:jedi-${CNAME}:${TAG} 2>&1 | tee singularity_build.log
+
+    get_ans "Push Singularity image to S3 and backup existing version?"
+    if [[ $ans == y ]] ; then
+       aws s3 mv s3://privatecontainers/jedi-${CNAME}.sif s3://privatecontainers/jedi-${CNAME}-revert.tar.gz
+       aws s3 cp containers/jedi-${CNAME}.sif s3://privatecontainers/jedi-${CNAME}.sif
+    fi
 fi
 
 echo "=============================================================="

--- a/docker_update_latest.sh
+++ b/docker_update_latest.sh
@@ -14,8 +14,7 @@ fi
 CNAME=${1:-"gnu-openmpi-dev"}
 TAG=${2:-"ecsync"}
 
-if [[ $(echo ${CNAME} | cut -d- -f1) = "intel19" ]]; then
-#if [[ $(echo ${CNAME} | cut -d- -f1) =~ "intel*" ]]; then
+if [[ $(echo ${CNAME} | cut -d- -f1) =~ "intel" ]]; then
 
   echo "Sending to Amazon S3"
   aws s3 mv s3://privatecontainers/docker-jedi-${CNAME}.tar.gz s3://privatecontainers/docker-jedi-${CNAME}-revert.tar.gz

--- a/docker_update_latest.sh
+++ b/docker_update_latest.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# This script is intended to push a given tag to docker hub
+# and tag it as latest.  The idea is that this is part of 
+# the container CI workflow.  After testing a particular
+# tag, you can then declare it as the version to be used 
+# in CI
+
+if [[ $# -lt 1 ]]; then
+   echo "usage: docker_update_latest.sh <name> <tag>"
+   exit 1
+fi
+
+CNAME=${1:-"gnu-openmpi-dev"}
+TAG=${2:-"ecsync"}
+
+if [[ $(echo ${CNAME} | cut -d- -f1) = "intel19" ]]; then
+#if [[ $(echo ${CNAME} | cut -d- -f1) =~ "intel*" ]]; then
+
+  echo "Sending to Amazon S3"
+  aws s3 mv s3://privatecontainers/docker-jedi-${CNAME}.tar.gz s3://privatecontainers/docker-jedi-${CNAME}-revert.tar.gz
+  aws s3 cp containers/docker-${CNAME}.tar.gz s3://privatecontainers/docker-jedi-${CNAME}.tar.gz
+
+else
+
+    # save previous image in case something goes wrong
+    docker pull jcsda/docker-$CNAME:latest
+    docker tag jcsda/docker-$CNAME:latest jcsda/docker-$CNAME:revert
+    docker push jcsda/docker-$CNAME:revert
+    docker rmi jcsda/docker-$CNAME:latest
+
+    # push new image and re-tag it with latest
+    docker tag jcsda/docker-$CNAME:${TAG} jcsda/docker-$CNAME:latest
+    docker rmi jcsda/docker-$CNAME:${TAG}
+    docker push jcsda/docker-$CNAME:latest
+
+fi


### PR DESCRIPTION

This small PR adds two features.

First, it adds a script that's useful for merge sprints like the one we did today.  This takes a tagged, tested docker container and then makes this the latest version on Docker Hub (gnu, clang) or S3 (intel).  And, it saves the previous one as revert.  The same functionality is already in the `build_intel_dev.sh` build script but this allows you to separate the workflow in the case that you don't want to update Docker Hub until the container is well tested and the other repos are ready.

Second, this adds the capability to make an intel development Singularity container.  Previously we had only been generating docker and charliecloud containers for intel-dev.