### PR TITLE
Bugfix/gdb

### DIFF
--- a/Dockerfile.intel19-impi-dev
+++ b/Dockerfile.intel19-impi-dev
@@ -50,16 +50,16 @@ RUN apt-get update -y && \
         build-essential \
         cpio && \
     rm -rf /var/lib/apt/lists/*
-COPY intel_tarballs/parallel_studio_xe_2020_update1_cluster_edition_online.tgz /var/tmp/parallel_studio_xe_2020_update1_cluster_edition_online.tgz
-COPY ../intel_license/COM_L___LXMW-67CW6CHW.lic /var/tmp/license.lic
-RUN mkdir -p /var/tmp && tar -x -f /var/tmp/parallel_studio_xe_2020_update1_cluster_edition_online.tgz -C /var/tmp -z && \
-    sed -i -e 's/^#\?\(COMPONENTS\)=.*/\1=intel-icc__x86_64;intel-ifort__x86_64;intel-mkl-core__x86_64;intel-ifort-common__noarch;intel-icx__x86_64;intel-icc-common__noarch;intel-icc-common-ps__noarch;intel-mkl-cluster__x86_64;intel-mkl-gnu__x86_64;intel-mkl-doc__noarch;intel-mkl-doc-ps__noarch;intel-mkl-common-ps__noarch;intel-mkl-core-ps__x86_64;intel-mkl-gnu-rt__x86_64;intel-mkl-common__noarch;intel-mkl-core-f__x86_64;intel-mkl-gnu-f__x86_64;intel-mkl-f95-common__noarch;intel-mkl-f__x86_64;intel-mkl-common-f__noarch;intel-mkl-cluster-c__noarch;intel-mkl-common-c-ps__noarch;intel-mkl-core-c__x86_64;intel-mkl-gnu-c__x86_64;intel-mkl-common-c__noarch;intel-mpi-rt__x86_64;intel-mpi-sdk__x86_64;intel-mpi-installer-license__x86_64;intel-mpi-psxe__x86_64;intel-mpi-rt-psxe__x86_64;intel-mkl-psxe__noarch;intel-ippcp-psxe__noarch;intel-psxe-common__noarch;intel-ippcp-psxe__noarch;intel-psxe-licensing__noarch;intel-icsxe-pset;intel-icsxe__noarch;intel-imb__x86_64;intel-ips__noarch;intel-ipsc__noarch;intel-ipsf__noarch;intel-openmp__x86_64;intel-openmp-common__noarch;intel-openmp-common-icc__noarch;intel-openmp-common-ifort__noarch;intel-openmp-ifort__x86_64;intel-comp__x86_64;intel-comp-l-all-common__noarch;intel-comp-l-all-vars__noarch;intel-comp-nomcu-vars__noarch;intel-comp-ps__x86_64;intel-comp-ps-ss-bec__x86_64/g' \
+COPY ./intel_tarballs/parallel_studio_xe_2020_cluster_edition.tgz /var/tmp/parallel_studio_xe_2020_cluster_edition.tgz
+COPY ./intel_license/COM_L___LXMW-67CW6CHW.lic /var/tmp/license.lic
+RUN mkdir -p /var/tmp && tar -x -f /var/tmp/parallel_studio_xe_2020_cluster_edition.tgz -C /var/tmp -z && \
+    sed -i -e 's/^#\?\(COMPONENTS\)=.*/\1=intel-icc__x86_64;intel-ifort__x86_64;intel-mkl-core__x86_64;intel-ifort-common__noarch;intel-icx__x86_64;intel-icc-common__noarch;intel-icc-common-ps__noarch;intel-mkl-cluster__x86_64;intel-mkl-gnu__x86_64;intel-mkl-doc__noarch;intel-mkl-doc-ps__noarch;intel-mkl-common-ps__noarch;intel-mkl-core-ps__x86_64;intel-mkl-gnu-rt__x86_64;intel-mkl-common__noarch;intel-mkl-core-f__x86_64;intel-mkl-gnu-f__x86_64;intel-mkl-f95-common__noarch;intel-mkl-f__x86_64;intel-mkl-common-f__noarch;intel-mkl-cluster-c__noarch;intel-mkl-common-c-ps__noarch;intel-mkl-core-c__x86_64;intel-mkl-gnu-c__x86_64;intel-mkl-common-c__noarch;intel-mpi-rt__x86_64;intel-mpi-sdk__x86_64;intel-mpi-installer-license__x86_64;intel-mpi-psxe__x86_64;intel-mpi-rt-psxe__x86_64;intel-mkl-psxe__noarch;intel-ippcp-psxe__noarch;intel-psxe-common__noarch;intel-ippcp-psxe__noarch;intel-psxe-licensing__noarch;intel-icsxe-pset;intel-icsxe__noarch;intel-imb__x86_64;intel-ips__noarch;intel-ipsc__noarch;intel-ipsf__noarch;intel-openmp__x86_64;intel-openmp-common__noarch;intel-openmp-common-icc__noarch;intel-openmp-common-ifort__noarch;intel-openmp-ifort__x86_64;intel-comp__x86_64;intel-comp-l-all-common__noarch;intel-comp-l-all-vars__noarch;intel-comp-nomcu-vars__noarch;intel-comp-ps__x86_64;intel-comp-ps-ss-bec__x86_64;intel-gdb__x86_64;intel-gdb-source__noarch;intel-gdb-common__noarch;intel-gdb-common-ps__noarch/g' \
         -e 's|^#\?\(PSET_INSTALL_DIR\)=.*|\1=/opt/intel|g' \
         -e 's/^#\?\(ACCEPT_EULA\)=.*/\1=accept/g' \
         -e 's/^#\?\(ACTIVATION_TYPE\)=.*/\1=license_file/g' \
-        -e 's|^#\?\(ACTIVATION_LICENSE_FILE\)=.*|\1=/var/tmp/license.lic|g' /var/tmp/parallel_studio_xe_2020_update1_cluster_edition_online/silent.cfg && \
-    cd /var/tmp/parallel_studio_xe_2020_update1_cluster_edition_online && ./install.sh --silent=silent.cfg && \
-    rm -rf /var/tmp/parallel_studio_xe_2020_update1_cluster_edition_online.tgz /var/tmp/parallel_studio_xe_2020_update1_cluster_edition_online
+        -e 's|^#\?\(ACTIVATION_LICENSE_FILE\)=.*|\1=/var/tmp/license.lic|g' /var/tmp/parallel_studio_xe_2020_cluster_edition/silent.cfg && \
+    cd /var/tmp/parallel_studio_xe_2020_cluster_edition && ./install.sh --silent=silent.cfg && \
+    rm -rf /var/tmp/parallel_studio_xe_2020_cluster_edition.tgz /var/tmp/parallel_studio_xe_2020_cluster_edition
 RUN echo "source /opt/intel/compilers_and_libraries/linux/bin/compilervars.sh intel64" >> /etc/bash.bashrc
 
 RUN rm -rf /opt/intel/advisor* /opt/intel/vtune* /opt/intel/inspector* && \
@@ -160,7 +160,7 @@ RUN useradd -U -k /etc/skel -s /bin/bash -d /home/jedi -m jedi && \
     echo "[credential]\n    helper = cache --timeout=7200" >> ~jedi/.gitconfig && \
     chown -R jedi:jedi ~jedi/.gitconfig
 
-ENV LD_LIBRARY_PATH=/opt/intel/compilers_and_libraries_2019/linux/lib/intel64_lin:/usr/local
+ENV LD_LIBRARY_PATH=/opt/intel/compilers_and_libraries_2020.0.166/linux/compiler/lib/intel64_lin:/usr/local
 
 ENTRYPOINT ["/bin/bash", "-l"]
 

--- a/build_intel_dev_container.sh
+++ b/build_intel_dev_container.sh
@@ -29,7 +29,7 @@ if [[ $(echo ${CNAME} | cut -d- -f1) = "intel17" ]]; then
     export INTEL_TARBALL='./intel_tarballs/parallel_studio_xe_2017_update1.tgz'
     export INTEL_CONTEXT='./context17'
 elif [[ $(echo ${CNAME} | cut -d- -f1) = "intel19" ]]; then
-    export INTEL_TARBALL='./intel_tarballs/parallel_studio_xe_2020_update1_cluster_edition_online.tgz'
+    export INTEL_TARBALL='./intel_tarballs/parallel_studio_xe_2020_cluster_edition.tgz'
     export INTEL_CONTEXT='./context19'
 fi
 

--- a/intel17-impi-dev.py
+++ b/intel17-impi-dev.py
@@ -21,7 +21,7 @@ Stage0 += apt_get(ospackages=['build-essential','tcsh','csh','ksh','lsb-release'
 #Stage0 += mlnx_ofed(version='4.5-1.0.1.0')
 
 # Install Intel compilers, mpi, and mkl
-Stage0 += intel_psxe(eula=True, license=os.getenv('INTEL_LICENSE_FILE',default='intel_license/COM_L___LXMW-67CW6CHW.lic'),
+Stage0 += intel_psxe(eula=True, license=os.getenv('INTEL_LICENSE_FILE'),
                      tarball=os.getenv('INTEL_TARBALL',default='intel_tarballs/parallel_studio_xe_2017_update1.tgz'),
                      psxevars=True, components=['intel-icc-l-all__x86_64',
                      'intel-ifort-l-ps__x86_64', 'intel-mkl__x86_64',

--- a/intel19-impi-app.py
+++ b/intel19-impi-app.py
@@ -70,7 +70,7 @@ if (hpc):
     Stage0 += u
 
 # Install Intel compilers, mpi, and mkl
-Stage0 += intel_psxe(eula=True, license=os.getenv('INTEL_LICENSE_FILE',default='../intel_license/COM_L___LXMW-67CW6CHW.lic'),
+Stage0 += intel_psxe(eula=True, license=os.getenv('INTEL_LICENSE_FILE'),
                      tarball=os.getenv('INTEL_TARBALL',default='intel_tarballs/parallel_studio_xe_2019_update5_cluster_edition.tgz'),
                      psxevars=True)
 

--- a/intel19-impi-dev.py
+++ b/intel19-impi-dev.py
@@ -29,8 +29,8 @@ Stage0 += shell(commands=['apt-key adv --keyserver keyserver.ubuntu.com --recv-k
 #Stage0 += mlnx_ofed(version='4.5-1.0.1.0')
 
 # Install Intel compilers, mpi, and mkl 
-Stage0 += intel_psxe(eula=True, license=os.getenv('INTEL_LICENSE_FILE',default='../intel_license/COM_L___LXMW-67CW6CHW.lic'),
-                     tarball=os.getenv('INTEL_TARBALL',default='intel_tarballs/parallel_studio_xe_2020_update1_cluster_edition_online.tgz'),
+Stage0 += intel_psxe(eula=True, license=os.getenv('INTEL_LICENSE_FILE'),
+                     tarball=os.getenv('INTEL_TARBALL',default='intel_tarballs/parallel_studio_xe_2020_cluster_edition.tgz'),
                      psxevars=True, components=['intel-icc__x86_64',
                       'intel-ifort__x86_64', 'intel-mkl-core__x86_64',
                       'intel-ifort-common__noarch',
@@ -80,7 +80,12 @@ Stage0 += intel_psxe(eula=True, license=os.getenv('INTEL_LICENSE_FILE',default='
                       'intel-comp-l-all-vars__noarch',
                       'intel-comp-nomcu-vars__noarch',
                       'intel-comp-ps__x86_64',
-                      'intel-comp-ps-ss-bec__x86_64'])
+                      'intel-comp-ps-ss-bec__x86_64',
+                      'intel-gdb__x86_64',
+                      'intel-gdb-source__noarch',
+                      'intel-gdb-common__noarch',
+                      'intel-gdb-common-ps__noarch'
+])
 
 # component specification still isn't working so delete directories manually
 if (reduced_size.lower() == "true"):
@@ -162,6 +167,7 @@ Stage0 += shell(commands=['useradd -U -k /etc/skel -s /bin/bash -d /home/jedi -m
     'chown -R jedi:jedi ~jedi/.gitconfig'])
 
 # this appears to be needed to avoid a bootup error message for docker run
-Stage0 += environment(variables={'LD_LIBRARY_PATH':'/opt/intel/compilers_and_libraries_2019/linux/lib/intel64_lin:/usr/local'})
+Stage0 += environment(variables={'LD_LIBRARY_PATH':'/opt/intel/compilers_and_libraries_2020.0.166/linux/compiler/lib/intel64_lin:/usr/local'})
+
 
 Stage0 += runscript(commands=['/bin/bash -l'])


### PR DESCRIPTION

This adds intel gdb (`gdb-ia`) to the intel19 container.  It increases the slze of the container by about 0.1 GB.  So, not too bad.

Also, I removed explicit mention of the name of the intel license file from the hpccm python scripts.  This can be set as an environment variable.  However, the name of the license file still appears in the auto-generated Docker files.  I'm not sure if exposing simply the name of the file is a security risk or not.  If it is (moving toward the possibility of making this repo public), then we can remove the Dockerfiles from the repo altogether, since they are autogenerated.   In any case, the file itself is not included in any github repos.  