### PR TITLE
instructions were pointing to the wrong build script

### DIFF
--- a/myIntel/Intel.md
+++ b/myIntel/Intel.md
@@ -26,7 +26,7 @@ The first step in building your own JEDI Intel Development Container is to clone
 
 ```
 git clone https://github.com/jcsda-internal/containers.git
-cd containers
+cd containers/myIntel
 ```
 
 Then enter the following command and respond to the questions - by default it will only build a Docker container but you can also build a Singularity container and/or a Charliecloud container if you wish:


### PR DESCRIPTION
## Description

The instructions for building your own Intel development container were pointing to the wrong build script

### Issue(s) addressed

None

## Acceptance Criteria (Definition of Done)

The instructions should work as described

## Dependencies

None

## Impact

None

## Test Data

None