### PR TITLE
modify conda python RPATH to solve openssl incompatibility

### DIFF
--- a/Singularity.gnu-openmpi-dev
+++ b/Singularity.gnu-openmpi-dev
@@ -13,6 +13,7 @@ SPECIES JEDI
     export LANG=en_US.UTF-8
     export LANGUAGE=en_US:en
     export PATH=/usr/local/bin:/usr/local/miniconda3/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
+    export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:/usr/local/lib:/usr/local/miniconda3/lib:/usr/local/miniconda3/pkgs/python-3.9.5-h12debd9_4/lib:/usr/lib:/usr/local/ucx/lib:/usr/local/xpmem/lib:/.singularity.d/libs
     alias pip=/usr/local/miniconda3/bin/pip
 
 %post

--- a/Singularity.gnu-openmpi-dev
+++ b/Singularity.gnu-openmpi-dev
@@ -17,8 +17,13 @@ SPECIES JEDI
 
 %post
     echo "Hello from inside the container"
+    apt-get update
+    apt-get install -y --no-install-recommends feh
+    apt-get install -y --no-install-recommends default-jre
+    apt-get install -y --no-install-recommends patchelf
     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
     bash Miniconda3-latest-Linux-x86_64.sh -b -p /usr/local/miniconda3
+    patchelf --set-rpath '/usr/lib/x86_64-linux-gnu:$ORIGIN/../lib' /usr/local/miniconda3/bin/python
     export PATH=/usr/local/miniconda3/bin:$PATH
     conda install numpy
     conda install matplotlib
@@ -28,9 +33,6 @@ SPECIES JEDI
     conda install -c conda-forge netcdf4
     conda install -c conda-forge xarray
     conda install -c conda-forge cartopy
-    apt-get update
-    apt-get install -y --no-install-recommends feh
-    apt-get install -y --no-install-recommends default-jre
     rm -rf /var/lib/apt/lists/*
 
 %runscript

--- a/Singularity.gnu-openmpi-dev
+++ b/Singularity.gnu-openmpi-dev
@@ -34,6 +34,7 @@ SPECIES JEDI
     conda install -c conda-forge netcdf4
     conda install -c conda-forge xarray
     conda install -c conda-forge cartopy
+    conda install -c anaconda pyyaml
     rm -rf /var/lib/apt/lists/*
 
 %runscript

--- a/Singularity.gnu-openmpi-dev
+++ b/Singularity.gnu-openmpi-dev
@@ -14,6 +14,7 @@ SPECIES JEDI
     export LANGUAGE=en_US:en
     export PATH=/usr/local/bin:/usr/local/miniconda3/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
     export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:/usr/local/lib:/usr/local/miniconda3/lib:/usr/local/miniconda3/pkgs/python-3.9.5-h12debd9_4/lib:/usr/lib:/usr/local/ucx/lib:/usr/local/xpmem/lib:/.singularity.d/libs
+    export PYTHONPATH=/usr/local/lib/python3.9/site-packages
     alias pip=/usr/local/miniconda3/bin/pip
 
 %post
@@ -36,6 +37,17 @@ SPECIES JEDI
     conda install -c conda-forge cartopy
     conda install -c anaconda pyyaml
     rm -rf /var/lib/apt/lists/*
+
+%post
+   git clone https://github.com/noaa-emc/NCEPLIBS-bufr.git
+   cd NCEPLIBS-bufr
+   git fetch
+   git checkout --detach bufr_v11.5.0
+   mkdir build
+   cd build
+   cmake -DENABLE_PYTHON=ON -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_INSTALL_LIBDIR=lib ..
+   make -j4
+   make install
 
 %runscript
     bash -l


### PR DESCRIPTION
## Description

Together with https://github.com/JCSDA-internal/ioda/pull/500, this seems to solve https://github.com/jcsda-internal/ioda/issues/463 in the gnu-openmpi-dev container.

More specifically, the `ctest -R python` tests currently fail for the develop branch of ioda in the gnu-openmpi-dev singularity container.  This is due to a conflict between the ioda python bindings and the libraries installed by conda, particularly openssl.  

Note: this is only a problem in the gnu-openmpi-dev singularity container.  Miniconda is not installed in the docker containers used for CI and it is not installed in the clang and intel singularity containers.  It is only installed in the gnu container because that is used for several of the [online tutorials](https://jointcenterforsatellitedataassimilation-jedi-docs.readthedocs-hosted.com/en/latest/learning/tutorials/index.html), which require python packages such as cartopy.

With this PR, the ioda python tests now pass in the singularity container.

If you would like to test it, a copy of the new container is available here:

```
aws s3 cp s3://privatecontainers/jedi-gnu-openmpi-dev_beta.sif .
```

Note that this container is not signed and I cannot push it to our repository on Sylabs cloud because @mer-a-o now manages that repository.  When she returns from PTO we can update the "official" `library::jcsda/public/gnu-openmpi-dev:latest` container.

### Issue(s) addressed

Link the issues to be closed with this PR
- partiall-fixes #https://github.com/jcsda-internal/ioda/issues/463


## Acceptance Criteria (Definition of Done)

All tests for the develop branch of ioda-bundle pass in the container:

```
100% tests passed, 0 tests failed out of 448
```

## Dependencies

None

## Impact

None
