### PR TITLE
Bugfix/noconda

### DIFF
--- a/Singularity.gnu-openmpi-dev
+++ b/Singularity.gnu-openmpi-dev
@@ -12,25 +12,34 @@ SPECIES JEDI
     export GIT_MERGE_AUTOEDIT
     export LANG=en_US.UTF-8
     export LANGUAGE=en_US:en
-    export PATH=/usr/local/bin:/usr/local/miniconda3/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
-    alias pip=/usr/local/miniconda3/bin/pip
+    export PATH=/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
 
 %post
     echo "Hello from inside the container"
-    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-    bash Miniconda3-latest-Linux-x86_64.sh -b -p /usr/local/miniconda3
-    export PATH=/usr/local/miniconda3/bin:$PATH
-    conda install numpy
-    conda install matplotlib
-    conda install click
-    conda install pandas
-    conda install -c conda-forge ruamel.yaml
-    conda install -c conda-forge netcdf4
-    conda install -c conda-forge xarray
-    conda install -c conda-forge cartopy
     apt-get update
+    apt-get install -y --no-install-recommends libsqlite3-dev libtiff-dev
+    apt-get install -y --no-install-recommends libgeos-dev libgeos++-dev
     apt-get install -y --no-install-recommends feh
     apt-get install -y --no-install-recommends default-jre
+    python3 -m pip install -U click
+    python3 -m pip install -U pandas
+    python3 -m pip install -U numpy
+    python3 -m pip install -U matplotlib
+    python3 -m pip install -U shapely
+    python3 -m pip install -U pyshp
+    python3 -m pip install -U ruamel.yaml
+    cd /root
+    wget https://download.osgeo.org/proj/proj-8.1.1.tar.gz
+    tar xvf proj-8.1.1.tar.gz
+    cd proj-8.1.1
+    mkdir build
+    cd build
+    cmake ..
+    cmake --build .
+    cmake --build . --target install
+    rm -rf /root/proj-*
+    python3 -m pip install -U pyproj
+    python3 -m pip install -U cartopy
     rm -rf /var/lib/apt/lists/*
 
 %runscript

--- a/Singularity.gnu-openmpi-dev
+++ b/Singularity.gnu-openmpi-dev
@@ -17,6 +17,7 @@ SPECIES JEDI
 %post
     echo "Hello from inside the container"
     apt-get update
+    apt-get install -y --no-install-recommends sqlite3
     apt-get install -y --no-install-recommends libsqlite3-dev libtiff-dev
     apt-get install -y --no-install-recommends libgeos-dev libgeos++-dev
     apt-get install -y --no-install-recommends feh
@@ -37,9 +38,9 @@ SPECIES JEDI
     cmake ..
     cmake --build .
     cmake --build . --target install
-    rm -rf /root/proj-*
     python3 -m pip install -U pyproj
     python3 -m pip install -U cartopy
+    rm -rf /root/proj-*
     rm -rf /var/lib/apt/lists/*
 
 %runscript


### PR DESCRIPTION
## Description

Currently the gnu-openmpi-dev singularity container is broken in the sense that, if a user downloads a develop branch of a bundle (any bundle that includes ioda), ecbuild will throw warnings, the ioda python tests will fail, and many of ioda-converters won't work.

As we have discussed in many meetings, this is [due to a conflict between conda-installed libraries and the ioda python bindings](https://github.com/JCSDA-internal/ioda/issues/463).

And, as we discussed this week, one short-term solution is just to avoid using conda where possible.

That is what this PR does.  It eliminates conda from the `gnu-openmpi-dev` container by installing `cartopy` and other python packages directly, with just `apt` and `pip`.

So, with this change, the container is no longer broken in the sense above.

I created a beta container for testing and put it on S3.  You can get it as follows.

```
aws s3 cp s3://privatecontainers/jedi-gnu-openmpi-dev_beta.sif .
```

Note: this container is not signed.  @mer-a-o - after others verify that it works, would you mind running the `build_containers.sh` script to generate and sign the container yourself?  Then you can push it to Sylabs cloud and replace the existing container?

No change is needed to the docker container or CI.  However, when I pulled the "latest" docker container, I saw that it was last modified 4 months ago.  I think we need to relabel the "beta" docker container (which we now use for CI, I believe) as "latest" on DockerHub.  

### Issue(s) addressed

Link the issues to be closed with this PR
- partially-fixes #https://github.com/JCSDA-internal/ioda/issues/463

## Acceptance Criteria (Definition of Done)

To test the ioda python bindings, I built a ioda-bundle that included ioda-converters and all tests passed:

```bash
100% tests passed, 0 tests failed out of 519
```

To test the `cartopy` and other python packages, I did the three mpas tutorials that use the `gnu-openmpi-dev` container.  Everything worked as it should.

One comment - I also built the latest release of fv3-bundle.  WIth both mpas-bundle and fv3-bundle I found a few intermittent failures:

```
	821 - test_ufo_linopr_gnssroBndNBAM (SEGFAULT)
```

```
	979 - fv3jedi_test_tier1_geometry_iterator_geos (SEGFAULT)
	1000 - fv3jedi_test_tier1_variablechange_gfs (SEGFAULT)
```

But, in both case, when I `--rerun-failed`, they passed.  But, in any case, I do not think these intermittent failures have anything to do with this PR.  We should address them elsewhere.



## Dependencies

None

## Impact

Impacts development work in the container.
